### PR TITLE
port-26.1-jei

### DIFF
--- a/changelog/26.1.md
+++ b/changelog/26.1.md
@@ -1,3 +1,6 @@
 # 26.12.0
 
 * Update to 26.1.2
+* Improved recipes shown in JEI
+  * However, no recipes will be shown in multiplayer mode in Fabric due to technical issue
+  * See com/kotori316/fluidtank/fabric/integration/jei/FluidTankJeiPlugin.scala

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     // We depend on fabric loader here to use the fabric @Environment annotations and get the mixin dependencies
     // Do NOT use other classes from fabric loader
     compileOnly("net.fabricmc:fabric-loader:${project.property("fabric_loader_version")}")
+    compileOnly("mezz.jei:jei-${project.property("jei_neoforge_repo_version")}-common-api:${project.property("jei_neoforge_version")}")
 
     testImplementation(
         "org.mockito:mockito-core:${project.property("mockitoCoreVersion")}"

--- a/common/src/main/scala/com/kotori316/fluidtank/integration/jei/JeiPluginConstant.scala
+++ b/common/src/main/scala/com/kotori316/fluidtank/integration/jei/JeiPluginConstant.scala
@@ -1,0 +1,8 @@
+package com.kotori316.fluidtank.integration.jei
+
+import com.kotori316.fluidtank.FluidTankCommon
+import net.minecraft.resources.Identifier
+
+object JeiPluginConstant {
+  val pluginUid: Identifier = Identifier.fromNamespaceAndPath(FluidTankCommon.modId, "jei_plugin")
+}

--- a/common/src/main/scala/com/kotori316/fluidtank/integration/jei/TierRecipeCraftingCategoryExtension.scala
+++ b/common/src/main/scala/com/kotori316/fluidtank/integration/jei/TierRecipeCraftingCategoryExtension.scala
@@ -1,0 +1,36 @@
+package com.kotori316.fluidtank.integration.jei
+
+import com.kotori316.fluidtank.recipe.TierRecipe
+import mezz.jei.api.recipe.category.extensions.vanilla.crafting.ICraftingCategoryExtension
+import net.minecraft.world.item.crafting.RecipeHolder
+import net.minecraft.world.item.crafting.display.{ShapedCraftingRecipeDisplay, SlotDisplay}
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+/**
+ * This class is used to remove the "Shapreless" icon from TierRecipe guides.
+ * The default implementation of [[ICraftingCategoryExtension]] treats only [[net.minecraft.world.item.crafting.ShapedRecipe]] and JEI class
+ * as shaped, and all other recipes are treated as shapless.
+ */
+class TierRecipeCraftingCategoryExtension extends ICraftingCategoryExtension[TierRecipe] {
+
+  /**
+   * Logic is copied from mezz.jei.library.plugins.vanilla.crafting.CraftingCategoryExtension#getIngredients
+   * Written in Scala syntax.
+   */
+  override def getIngredients(recipeHolder: RecipeHolder[TierRecipe]): java.util.List[SlotDisplay] = {
+    recipeHolder
+      .value()
+      .display()
+      .asScala
+      .headOption
+      .collect { case display: ShapedCraftingRecipeDisplay => display.ingredients() }
+      .getOrElse(java.util.List.of())
+  }
+
+  override def getWidth(recipeHolder: RecipeHolder[TierRecipe]): Int = 3
+
+  override def getHeight(recipeHolder: RecipeHolder[TierRecipe]): Int = 3
+
+  override def isHandled(recipe: RecipeHolder[TierRecipe]): Boolean = true
+}

--- a/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipe.java
+++ b/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipe.java
@@ -22,8 +22,12 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ItemStackTemplate;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.TypedEntityData;
 import net.minecraft.world.item.crafting.*;
+import net.minecraft.world.item.crafting.display.RecipeDisplay;
+import net.minecraft.world.item.crafting.display.ShapedCraftingRecipeDisplay;
+import net.minecraft.world.item.crafting.display.SlotDisplay;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.TagValueOutput;
 import org.jetbrains.annotations.NotNull;
@@ -137,6 +141,21 @@ public final class TierRecipe extends NormalCraftingRecipe implements CraftingRe
     @Override
     protected PlacementInfo createPlacementInfo() {
         return PlacementInfo.createFromOptionals(this.pattern.ingredients());
+    }
+
+    /**
+     * Copied from {@link ShapedRecipe#display()}
+     */
+    @Override
+    public List<RecipeDisplay> display() {
+        return List.of(
+            new ShapedCraftingRecipeDisplay(
+                3, 3,
+                this.pattern.ingredients().stream().map(e -> e.map(Ingredient::display).orElse(SlotDisplay.Empty.INSTANCE)).toList(),
+                new SlotDisplay.ItemStackSlotDisplay(this.result),
+                new SlotDisplay.ItemSlotDisplay(Items.CRAFTING_TABLE)
+            )
+        );
     }
 
     @NotNull

--- a/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipe.java
+++ b/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipe.java
@@ -52,7 +52,7 @@ public final class TierRecipe extends NormalCraftingRecipe implements CraftingRe
     final Tier tier;
     final Ingredient tankItem;
     final Ingredient subItem;
-    final ItemStackTemplate result;
+    public final ItemStackTemplate result;
     final ShapedRecipePattern pattern;
 
     public TierRecipe(Tier tier, Ingredient tankItem, Ingredient subItem) {
@@ -182,12 +182,16 @@ public final class TierRecipe extends NormalCraftingRecipe implements CraftingRe
         return tier;
     }
 
-    private Ingredient getSubItem() {
+    public Ingredient getTankItem() {
+        return tankItem;
+    }
+
+    public Ingredient getSubItem() {
         return this.subItem;
     }
 
     @VisibleForTesting
-    public ItemStack getResult() {
+    public ItemStack getResultItemStack() {
         return result.create();
     }
 

--- a/dependency-check/build.gradle.kts
+++ b/dependency-check/build.gradle.kts
@@ -4,25 +4,9 @@ plugins {
 
 dependencies {
     // JEI
-    implementation(
-        group = "mezz.jei",
-        name = "jei-${project.property("jei_forge_repo_version")}-forge",
-        version = project.property("jei_forge_version").toString()
-    )
-    implementation(
-        group = "mezz.jei",
-        name = "jei-${project.property("jei_fabric_repo_version")}-fabric",
-        version = project.property("jei_fabric_version").toString()
-    )
-    implementation(
-        group = "mezz.jei",
-        name = "jei-${project.property("jei_neoforge_repo_version")}-neoforge",
-        version = project.property("jei_neoforge_version").toString()
-    )
+    implementation("mezz.jei:jei-${project.property("jei_neoforge_repo_version")}-common-api:${project.property("jei_neoforge_version")}")
+    implementation("mezz.jei:jei-${project.property("jei_fabric_repo_version")}-fabric:${project.property("jei_fabric_version")}")
+    implementation("mezz.jei:jei-${project.property("jei_neoforge_repo_version")}-neoforge:${project.property("jei_neoforge_version")}")
     // Scala 3
-    implementation(
-        group = "org.scala-lang",
-        name = "scala3-library_3",
-        version = project.property("scala3_version") as String
-    )
+    implementation("org.scala-lang:scala3-library_3:${project.property("scala3_version")}")
 }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -102,11 +102,8 @@ dependencies {
     implementation(
         "curse.maven:jade-324717:${project.property("jade_fabric_id")}"
     )
-    /*runtimeOnly(
-        group = "mezz.jei",
-        name = "jei-${project.property("jei_fabric_repo_version")}-fabric",
-        version = project.property("jei_fabric_version").toString()
-    )*/
+    compileOnly("mezz.jei:jei-${project.property("jei_fabric_repo_version")}-fabric-api:${project.property("jei_fabric_version")}")
+    runtimeOnly("mezz.jei:jei-${project.property("jei_fabric_repo_version")}-fabric:${project.property("jei_fabric_version")}")
     //noinspection SpellCheckingInspection
     implementation(
         "teamreborn:energy:${project.property("fabric_energy_version")}"

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -24,6 +24,9 @@
     ],
     "jade": [
       "com.kotori316.fluidtank.fabric.integration.jade.FluidTankJadePlugin"
+    ],
+    "jei_mod_plugin": [
+      "com.kotori316.fluidtank.fabric.integration.jei.FluidTankJeiPlugin"
     ]
   },
   "depends": {

--- a/fabric/src/main/scala/com/kotori316/fluidtank/fabric/integration/jei/FluidTankJeiPlugin.scala
+++ b/fabric/src/main/scala/com/kotori316/fluidtank/fabric/integration/jei/FluidTankJeiPlugin.scala
@@ -1,0 +1,57 @@
+package com.kotori316.fluidtank.fabric.integration.jei
+
+import com.kotori316.fluidtank.FluidTankCommon
+import com.kotori316.fluidtank.integration.jei.{JeiPluginConstant, TierRecipeCraftingCategoryExtension}
+import com.kotori316.fluidtank.recipe.TierRecipe
+import mezz.jei.api.constants.RecipeTypes
+import mezz.jei.api.registration.{IRecipeRegistration, IVanillaCategoryExtensionRegistration}
+import mezz.jei.api.{IModPlugin, JeiPlugin}
+import net.minecraft.client.Minecraft
+import net.minecraft.core.registries.Registries
+import net.minecraft.resources.{Identifier, ResourceKey}
+import net.minecraft.world.item.crafting.display.SlotDisplay
+import net.minecraft.world.item.crafting.{CraftingRecipe, RecipeHolder}
+import org.slf4j.LoggerFactory
+
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, SeqHasAsJava}
+
+@JeiPlugin
+class FluidTankJeiPlugin extends IModPlugin {
+  private val LOGGER = LoggerFactory.getLogger(classOf[FluidTankJeiPlugin])
+
+  override def getPluginUid: Identifier = JeiPluginConstant.pluginUid
+
+  override def registerVanillaCategoryExtensions(registration: IVanillaCategoryExtensionRegistration): Unit = {
+    LOGGER.info("Registering TierRecipe CategoryExtension for JEI with Fabric")
+    super.registerVanillaCategoryExtensions(registration)
+    registration.getCraftingCategory.addExtension(classOf[TierRecipe], new TierRecipeCraftingCategoryExtension)
+  }
+
+  override def registerRecipes(registration: IRecipeRegistration): Unit = {
+    super.registerRecipes(registration)
+
+    // TODO how to get TierRecipes in delegated server?
+    val tierRecipes = for {
+      server <- Option(Minecraft.getInstance().getSingleplayerServer).iterator.to(IndexedSeq)
+      recipeHolder <- server.getRecipeManager.getRecipes.asScala
+      recipe <- Option(recipeHolder.value()).collect { case r: TierRecipe => r }
+    } yield createJeiShapedRecipe(registration, recipe)
+
+    LOGGER.info("Registering TierRecipe recipes for JEI with Fabric, count: {}", tierRecipes.size)
+    registration.addRecipes(RecipeTypes.CRAFTING, tierRecipes.asJava)
+  }
+
+  private def createJeiShapedRecipe(registration: IRecipeRegistration, r: TierRecipe): RecipeHolder[CraftingRecipe] = {
+    val builder = registration.getVanillaRecipeFactory.createShapedRecipeBuilder(r.category(), new SlotDisplay.ItemStackSlotDisplay(r.result))
+    val recipe = builder
+      .group(r.group())
+      .pattern("tst")
+      .pattern("s s")
+      .pattern("tst")
+      .define('t', r.getTankItem)
+      .define('s', r.getSubItem)
+      .build()
+    val key = ResourceKey.create(Registries.RECIPE, Identifier.fromNamespaceAndPath(FluidTankCommon.modId, s"jei_dummy_${r.getTier.name.toLowerCase}"))
+    new RecipeHolder(key, recipe)
+  }
+}

--- a/fabric/src/test/scala/com/kotori316/fluidtank/fabric/gametest/RecipeTest.java
+++ b/fabric/src/test/scala/com/kotori316/fluidtank/fabric/gametest/RecipeTest.java
@@ -236,7 +236,7 @@ public final class RecipeTest {
             "Loaded recipe is not TierRecipe");
         assertNotNull(deserialized);
         assertAll(
-            () -> assertTrue(ItemStack.matches(recipe.getResult(), deserialized.getResult()))
+            () -> assertTrue(ItemStack.matches(recipe.getResultItemStack(), deserialized.getResultItemStack()))
         );
         helper.succeed();
     }
@@ -251,7 +251,7 @@ public final class RecipeTest {
         var deserialized = TierRecipe.Serializer.fromNetwork(buffer);
         assertNotNull(deserialized);
         assertAll(
-            () -> assertTrue(ItemStack.matches(recipe.getResult(), deserialized.getResult()))
+            () -> assertTrue(ItemStack.matches(recipe.getResultItemStack(), deserialized.getResultItemStack()))
         );
         helper.succeed();
     }
@@ -270,7 +270,7 @@ public final class RecipeTest {
             Tier.STONE, TierRecipe.Serializer.getIngredientTankForTier(Tier.STONE), Ingredient.of(Items.DIAMOND));
 
         assertAll(
-            () -> assertTrue(ItemStack.matches(recipe.getResult(), read.getResult()))
+            () -> assertTrue(ItemStack.matches(recipe.getResultItemStack(), read.getResultItemStack()))
         );
         helper.succeed();
     }

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -135,9 +135,10 @@ dependencies {
     compileOnly(
         "appeng:appliedenergistics2:${project.property("ae2_neoforge_version")}"
     ) { isTransitive = false }
-    /*implementation(
-        "mezz.jei:jei-${project.property("jei_neoforge_repo_version")}-neoforge:${project.property("jei_neoforge_version")}"
-    ) { isTransitive = false }*/
+    compileOnly("mezz.jei:jei-${project.property("jei_neoforge_repo_version")}-neoforge-api:${project.property("jei_neoforge_version")}")
+    runtimeOnly("mezz.jei:jei-${project.property("jei_neoforge_repo_version")}-neoforge:${project.property("jei_neoforge_version")}") {
+        isTransitive = false
+    }
     // Test Dependencies.
     // Required these libraries to execute the tests.
     // The library will avoid errors of ForgeRegistry and Capability.

--- a/neoforge/src/gameTest/scala/com/kotori316/fluidtank/neoforge/gametest/RecipeTest.java
+++ b/neoforge/src/gameTest/scala/com/kotori316/fluidtank/neoforge/gametest/RecipeTest.java
@@ -207,7 +207,7 @@ final class RecipeTest {
             "Loaded recipe is not TierRecipe");
         assertNotNull(deserialized);
         assertAll(
-            () -> assertTrue(ItemStack.matches(recipe.getResult(), deserialized.getResult()))
+            () -> assertTrue(ItemStack.matches(recipe.getResultItemStack(), deserialized.getResultItemStack()))
         );
         helper.succeed();
     }
@@ -222,7 +222,7 @@ final class RecipeTest {
         var deserialized = streamCodec.decode(buffer);
         assertNotNull(deserialized);
         assertAll(
-            () -> assertTrue(ItemStack.matches(recipe.getResult(), deserialized.getResult()))
+            () -> assertTrue(ItemStack.matches(recipe.getResultItemStack(), deserialized.getResultItemStack()))
         );
         helper.succeed();
     }
@@ -241,7 +241,7 @@ final class RecipeTest {
             Tier.STONE, TierRecipe.Serializer.getIngredientTankForTier(Tier.STONE), Ingredient.of(Items.DIAMOND));
 
         assertAll(
-            () -> assertTrue(ItemStack.matches(recipe.getResult(), read.getResult()))
+            () -> assertTrue(ItemStack.matches(recipe.getResultItemStack(), read.getResultItemStack()))
         );
         helper.succeed();
     }

--- a/neoforge/src/main/scala/com/kotori316/fluidtank/neoforge/integration/jei/FluidTankJeiPlugin.scala
+++ b/neoforge/src/main/scala/com/kotori316/fluidtank/neoforge/integration/jei/FluidTankJeiPlugin.scala
@@ -1,0 +1,21 @@
+package com.kotori316.fluidtank.neoforge.integration.jei
+
+import com.kotori316.fluidtank.integration.jei.{JeiPluginConstant, TierRecipeCraftingCategoryExtension}
+import com.kotori316.fluidtank.recipe.TierRecipe
+import mezz.jei.api.registration.IVanillaCategoryExtensionRegistration
+import mezz.jei.api.{IModPlugin, JeiPlugin}
+import net.minecraft.resources.Identifier
+import org.slf4j.LoggerFactory
+
+@JeiPlugin
+class FluidTankJeiPlugin extends IModPlugin {
+  private val LOGGER = LoggerFactory.getLogger(classOf[FluidTankJeiPlugin])
+
+  override def getPluginUid: Identifier = JeiPluginConstant.pluginUid
+
+  override def registerVanillaCategoryExtensions(registration: IVanillaCategoryExtensionRegistration): Unit = {
+    LOGGER.info("Registering TierRecipe CategoryExtension for JEI with NeoForge")
+    super.registerVanillaCategoryExtensions(registration)
+    registration.getCraftingCategory.addExtension(classOf[TierRecipe], new TierRecipeCraftingCategoryExtension)
+  }
+}


### PR DESCRIPTION
Improve JEI visual for tank recipes.

In fabric, the TierRecipe instances are not sent from the server in sync process, so I register recipes by checking the server recipe manager, but this workaround doesn't work in multiplayer server.
The recipes themselves are registered and items can be created.

In neo, works fine.