### PR TITLE
Refine recipe sync logic in 26.1.2 fabric

### DIFF
--- a/changelog/26.1.md
+++ b/changelog/26.1.md
@@ -2,5 +2,3 @@
 
 * Update to 26.1.2
 * Improved recipes shown in JEI
-  * However, no recipes will be shown in multiplayer mode in Fabric due to technical issue
-  * See com/kotori316/fluidtank/fabric/integration/jei/FluidTankJeiPlugin.scala

--- a/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipe.java
+++ b/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipe.java
@@ -11,7 +11,6 @@ import com.kotori316.fluidtank.fluids.FluidLike;
 import com.kotori316.fluidtank.fluids.FluidLikeKey;
 import com.kotori316.fluidtank.item.PlatformItemAccess;
 import com.kotori316.fluidtank.tank.*;
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.NonNullList;
@@ -52,7 +51,7 @@ public final class TierRecipe extends NormalCraftingRecipe implements CraftingRe
     final Tier tier;
     final Ingredient tankItem;
     final Ingredient subItem;
-    public final ItemStackTemplate result;
+    final ItemStackTemplate result;
     final ShapedRecipePattern pattern;
 
     public TierRecipe(Recipe.CommonInfo info, CraftingRecipe.CraftingBookInfo bookInfo, Tier tier, Ingredient tankItem, Ingredient subItem) {
@@ -175,18 +174,6 @@ public final class TierRecipe extends NormalCraftingRecipe implements CraftingRe
         return template.create();
     }
 
-    public Tier getTier() {
-        return tier;
-    }
-
-    public Ingredient getTankItem() {
-        return tankItem;
-    }
-
-    public Ingredient getSubItem() {
-        return this.subItem;
-    }
-
     @VisibleForTesting
     public ItemStack getResultItemStack() {
         return result.create();
@@ -201,8 +188,8 @@ public final class TierRecipe extends NormalCraftingRecipe implements CraftingRe
             instance.group(
                 Recipe.CommonInfo.MAP_CODEC.forGetter(o -> o.commonInfo),
                 CraftingRecipe.CraftingBookInfo.MAP_CODEC.forGetter(o -> o.bookInfo),
-                Codec.STRING.xmap(Tier::valueOfIgnoreCase, Tier::name).fieldOf(KEY_TIER).forGetter(TierRecipe::getTier),
-                Ingredient.CODEC.fieldOf(KEY_SUB_ITEM).forGetter(TierRecipe::getSubItem)
+                Tier.CODEC.fieldOf(KEY_TIER).forGetter(o -> o.tier),
+                Ingredient.CODEC.fieldOf(KEY_SUB_ITEM).forGetter(o -> o.subItem)
             ).apply(instance, Serializer::createInstanceInternal)
         );
         public static final StreamCodec<RegistryFriendlyByteBuf, TierRecipe> STREAM_CODEC =

--- a/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipe.java
+++ b/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipe.java
@@ -55,11 +55,8 @@ public final class TierRecipe extends NormalCraftingRecipe implements CraftingRe
     public final ItemStackTemplate result;
     final ShapedRecipePattern pattern;
 
-    public TierRecipe(Tier tier, Ingredient tankItem, Ingredient subItem) {
-        super(
-            new Recipe.CommonInfo(false),
-            new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TANK_RECIPE_GROUP)
-        );
+    public TierRecipe(Recipe.CommonInfo info, CraftingRecipe.CraftingBookInfo bookInfo, Tier tier, Ingredient tankItem, Ingredient subItem) {
+        super(info, bookInfo);
         this.tier = tier;
         this.tankItem = tankItem;
         this.subItem = subItem;
@@ -202,6 +199,8 @@ public final class TierRecipe extends NormalCraftingRecipe implements CraftingRe
         public static final Identifier LOCATION = Identifier.fromNamespaceAndPath(FluidTankCommon.modId, "crafting_grade_up");
         public static final MapCodec<TierRecipe> CODEC = RecordCodecBuilder.mapCodec(instance ->
             instance.group(
+                Recipe.CommonInfo.MAP_CODEC.forGetter(o -> o.commonInfo),
+                CraftingRecipe.CraftingBookInfo.MAP_CODEC.forGetter(o -> o.bookInfo),
                 Codec.STRING.xmap(Tier::valueOfIgnoreCase, Tier::name).fieldOf(KEY_TIER).forGetter(TierRecipe::getTier),
                 Ingredient.CODEC.fieldOf(KEY_SUB_ITEM).forGetter(TierRecipe::getSubItem)
             ).apply(instance, Serializer::createInstanceInternal)
@@ -209,25 +208,25 @@ public final class TierRecipe extends NormalCraftingRecipe implements CraftingRe
         public static final StreamCodec<RegistryFriendlyByteBuf, TierRecipe> STREAM_CODEC =
             StreamCodec.ofMember(Serializer::toNetwork, Serializer::fromNetwork);
 
-        private static TierRecipe createInstance(Tier tier, Ingredient tankItem, Ingredient subItem) {
-            return new TierRecipe(tier, tankItem, subItem);
-        }
-
-        private static TierRecipe createInstanceInternal(Tier tier, Ingredient subItem) {
-            return createInstance(tier, getIngredientTankForTier(tier), subItem);
+        private static TierRecipe createInstanceInternal(Recipe.CommonInfo info, CraftingRecipe.CraftingBookInfo bookInfo, Tier tier, Ingredient subItem) {
+            return new TierRecipe(info, bookInfo, tier, getIngredientTankForTier(tier), subItem);
         }
 
         public static TierRecipe fromNetwork(RegistryFriendlyByteBuf buffer) {
+            var info = Recipe.CommonInfo.STREAM_CODEC.decode(buffer);
+            var bookInfo = CraftingRecipe.CraftingBookInfo.STREAM_CODEC.decode(buffer);
             String tierName = buffer.readUtf();
             Tier tier = Tier.valueOf(tierName);
             Ingredient tankItem = Ingredient.CONTENTS_STREAM_CODEC.decode(buffer);
             Ingredient subItem = Ingredient.CONTENTS_STREAM_CODEC.decode(buffer);
 
             DebugLogging.LOGGER().debug("Serializer loaded from packet for tier {}, sub {}.", tier, PlatformItemAccess.convertIngredientToString(subItem));
-            return createInstance(tier, tankItem, subItem);
+            return new TierRecipe(info, bookInfo, tier, tankItem, subItem);
         }
 
         public static void toNetwork(TierRecipe recipe, RegistryFriendlyByteBuf buffer) {
+            Recipe.CommonInfo.STREAM_CODEC.encode(buffer, recipe.commonInfo);
+            CraftingRecipe.CraftingBookInfo.STREAM_CODEC.encode(buffer, recipe.bookInfo);
             buffer.writeUtf(recipe.tier.name());
             Ingredient.CONTENTS_STREAM_CODEC.encode(buffer, recipe.tankItem);
             Ingredient.CONTENTS_STREAM_CODEC.encode(buffer, recipe.subItem);

--- a/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipeBuilder.java
+++ b/common/src/main/scala/com/kotori316/fluidtank/recipe/TierRecipeBuilder.java
@@ -10,6 +10,8 @@ import net.minecraft.data.recipes.RecipeBuilder;
 import net.minecraft.data.recipes.RecipeCategory;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import org.jetbrains.annotations.Nullable;
@@ -23,7 +25,7 @@ public final class TierRecipeBuilder implements RecipeBuilder {
     private final TierRecipe recipe;
 
     public TierRecipeBuilder(Tier tier, Ingredient tankItem, Ingredient subItem) {
-        this.recipe = new TierRecipe(tier, tankItem, subItem);
+        this.recipe = new TierRecipe(new Recipe.CommonInfo(true), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP), tier, tankItem, subItem);
     }
 
     @Override

--- a/common/src/main/scala/com/kotori316/fluidtank/tank/Tier.java
+++ b/common/src/main/scala/com/kotori316/fluidtank/tank/Tier.java
@@ -3,6 +3,7 @@ package com.kotori316.fluidtank.tank;
 import com.google.common.base.CaseFormat;
 import com.kotori316.fluidtank.config.PlatformConfigAccess;
 import com.kotori316.fluidtank.contents.GenericUnit;
+import com.mojang.serialization.Codec;
 import org.jetbrains.annotations.NotNull;
 import scala.math.BigInt;
 
@@ -27,6 +28,8 @@ public enum Tier {
     LEAD(3),
     SILVER(3),
     ;
+
+    public static final Codec<Tier> CODEC = Codec.STRING.xmap(Tier::valueOfIgnoreCase, Tier::name);
 
     private final int rank;
     private final String blockName;

--- a/fabric/game-test/server.properties
+++ b/fabric/game-test/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Wed May 06 19:28:27 JST 2026
+#Wed May 06 20:23:22 JST 2026
 accepts-transfers=false
 allow-flight=true
 allow-nether=true

--- a/fabric/game-test/server.properties
+++ b/fabric/game-test/server.properties
@@ -1,5 +1,5 @@
 #Minecraft server properties
-#Tue May 05 13:53:02 JST 2026
+#Wed May 06 19:28:27 JST 2026
 accepts-transfers=false
 allow-flight=true
 allow-nether=true

--- a/fabric/src/dataGen/scala/com/kotori316/fluidtank/fabric/data/IngredientProviderFabric.scala
+++ b/fabric/src/dataGen/scala/com/kotori316/fluidtank/fabric/data/IngredientProviderFabric.scala
@@ -9,7 +9,7 @@ import net.minecraft.core.registries.Registries
 import net.minecraft.data.recipes.RecipeOutput
 import net.minecraft.resources.Identifier
 import net.minecraft.tags.{ItemTags, TagKey}
-import net.minecraft.world.item.{Item, Items}
+import net.minecraft.world.item.Item
 
 class IngredientProviderFabric(i: HolderGetter[Item], withCondition: (RecipeOutput, Seq[ResourceCondition]) => RecipeOutput) extends IngredientProvider {
   override given itemRegistry: HolderGetter[Item] = i
@@ -31,7 +31,7 @@ class IngredientProviderFabric(i: HolderGetter[Item], withCondition: (RecipeOutp
       case Tier.GOLD => TankSubitem(ConventionalItemTags.GOLD_INGOTS)
       case Tier.DIAMOND => TankSubitem(ConventionalItemTags.DIAMOND_GEMS)
       case Tier.EMERALD => TankSubitem(ConventionalItemTags.EMERALD_GEMS)
-      case Tier.STAR => TankSubitem(Items.NETHER_STAR)
+      case Tier.STAR => TankSubitem(ConventionalItemTags.NETHER_STARS)
       case Tier.VOID => TankSubitem(obsidianTag)
       case Tier.COPPER => TankSubitem(ConventionalItemTags.COPPER_INGOTS)
       case Tier.TIN => TankSubitem(TagKey.create(Registries.ITEM, Identifier.fromNamespaceAndPath(TagUtil.C_TAG_NAMESPACE, "ingots/tin")))

--- a/fabric/src/generated/resources/data/fluidtank/advancement/recipes/decorations/tank_star.json
+++ b/fabric/src/generated/resources/data/fluidtank/advancement/recipes/decorations/tank_star.json
@@ -1,11 +1,20 @@
 {
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:tags_populated",
+      "registry": "minecraft:item",
+      "values": [
+        "c:nether_stars"
+      ]
+    }
+  ],
   "parent": "minecraft:recipes/root",
   "criteria": {
     "has_ingredient": {
       "conditions": {
         "items": [
           {
-            "items": "minecraft:nether_star"
+            "items": "#c:nether_stars"
           }
         ]
       },

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_bronze.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_bronze.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/bronze",
   "tier": "BRONZE"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_copper.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_copper.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/copper",
   "tier": "COPPER"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_diamond.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_diamond.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:gems/diamond",
   "tier": "DIAMOND"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_emerald.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_emerald.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:gems/emerald",
   "tier": "EMERALD"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_gold.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_gold.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/gold",
   "tier": "GOLD"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_iron.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_iron.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/iron",
   "tier": "IRON"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_lead.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_lead.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/lead",
   "tier": "LEAD"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_silver.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_silver.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/silver",
   "tier": "SILVER"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_star.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_star.json
@@ -1,5 +1,7 @@
 {
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "minecraft:nether_star",
   "tier": "STAR"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_star.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_star.json
@@ -1,7 +1,16 @@
 {
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:tags_populated",
+      "registry": "minecraft:item",
+      "values": [
+        "c:nether_stars"
+      ]
+    }
+  ],
   "type": "fluidtank:crafting_grade_up",
   "category": "misc",
   "group": "fluidtank_tank",
-  "sub_item": "minecraft:nether_star",
+  "sub_item": "#c:nether_stars",
   "tier": "STAR"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_stone.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_stone.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:stones",
   "tier": "STONE"
 }

--- a/fabric/src/generated/resources/data/fluidtank/recipe/tank_tin.json
+++ b/fabric/src/generated/resources/data/fluidtank/recipe/tank_tin.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/tin",
   "tier": "TIN"
 }

--- a/fabric/src/main/scala/com/kotori316/fluidtank/fabric/FluidTank.java
+++ b/fabric/src/main/scala/com/kotori316/fluidtank/fabric/FluidTank.java
@@ -23,6 +23,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.creativetab.v1.FabricCreativeModeTab;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
+import net.fabricmc.fabric.api.recipe.v1.sync.RecipeSynchronization;
 import net.minecraft.core.Registry;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -90,6 +91,7 @@ public final class FluidTank implements ModInitializer {
             .forEach((c, t) -> Registry.register(BuiltInRegistries.BLOCK_ENTITY_TYPE, Identifier.fromNamespaceAndPath(FluidTankCommon.modId, c.getSimpleName().toLowerCase(Locale.ROOT)), t));
         Registry.register(BuiltInRegistries.LOOT_FUNCTION_TYPE, Identifier.fromNamespaceAndPath(FluidTankCommon.modId, TankLootFunction.NAME), TANK_LOOT_FUNCTION);
         Registry.register(BuiltInRegistries.RECIPE_SERIALIZER, TierRecipe.Serializer.LOCATION, TIER_RECIPE_SERIALIZER);
+        RecipeSynchronization.synchronizeRecipeSerializer(TIER_RECIPE_SERIALIZER);
         Registry.register(BuiltInRegistries.BLOCK, Identifier.fromNamespaceAndPath(FluidTankCommon.modId, BlockChestAsTank.NAME()), BLOCK_CAT);
         Registry.register(BuiltInRegistries.ITEM, Identifier.fromNamespaceAndPath(FluidTankCommon.modId, BlockChestAsTank.NAME()), ITEM_CAT);
         RESERVOIR_MAP.values().forEach(e -> Registry.register(BuiltInRegistries.ITEM, Identifier.fromNamespaceAndPath(FluidTankCommon.modId, "reservoir_" + e.tier().name().toLowerCase(Locale.ROOT)), e));

--- a/fabric/src/main/scala/com/kotori316/fluidtank/fabric/integration/jei/FluidTankJeiPlugin.scala
+++ b/fabric/src/main/scala/com/kotori316/fluidtank/fabric/integration/jei/FluidTankJeiPlugin.scala
@@ -1,27 +1,15 @@
 package com.kotori316.fluidtank.fabric.integration.jei
 
-import com.kotori316.fluidtank.FluidTankCommon
 import com.kotori316.fluidtank.integration.jei.{JeiPluginConstant, TierRecipeCraftingCategoryExtension}
 import com.kotori316.fluidtank.recipe.TierRecipe
-import mezz.jei.api.constants.RecipeTypes
-import mezz.jei.api.registration.{IRecipeRegistration, IVanillaCategoryExtensionRegistration}
+import mezz.jei.api.registration.IVanillaCategoryExtensionRegistration
 import mezz.jei.api.{IModPlugin, JeiPlugin}
-import net.fabricmc.fabric.api.client.recipe.v1.sync.ClientRecipeSynchronizedEvent
-import net.fabricmc.fabric.api.recipe.v1.sync.SynchronizedRecipes
-import net.minecraft.core.registries.Registries
-import net.minecraft.resources.{Identifier, ResourceKey}
-import net.minecraft.world.item.crafting.display.SlotDisplay
-import net.minecraft.world.item.crafting.{CraftingRecipe, RecipeHolder, RecipeType}
+import net.minecraft.resources.Identifier
 import org.slf4j.LoggerFactory
-
-import scala.jdk.CollectionConverters.{CollectionHasAsScala, SeqHasAsJava}
 
 @JeiPlugin
 class FluidTankJeiPlugin extends IModPlugin {
   private val LOGGER = LoggerFactory.getLogger(classOf[FluidTankJeiPlugin])
-
-  private var recipeMap: Option[SynchronizedRecipes] = None
-  ClientRecipeSynchronizedEvent.EVENT.register((client, recipes) => recipeMap = Option(recipes))
 
   override def getPluginUid: Identifier = JeiPluginConstant.pluginUid
 
@@ -29,32 +17,5 @@ class FluidTankJeiPlugin extends IModPlugin {
     LOGGER.info("Registering TierRecipe CategoryExtension for JEI with Fabric")
     super.registerVanillaCategoryExtensions(registration)
     registration.getCraftingCategory.addExtension(classOf[TierRecipe], new TierRecipeCraftingCategoryExtension)
-  }
-
-  override def registerRecipes(registration: IRecipeRegistration): Unit = {
-    super.registerRecipes(registration)
-    val tierRecipes = this.recipeMap.iterator
-      .flatMap(_.getAllOfType(RecipeType.CRAFTING).asScala)
-      .map(_.value())
-      .collect { case r: TierRecipe => r }
-      .map(createJeiShapedRecipe(registration, _))
-      .toSeq
-
-    LOGGER.info("Registering TierRecipe recipes for JEI with Fabric, count: {}", tierRecipes.size)
-    registration.addRecipes(RecipeTypes.CRAFTING, tierRecipes.asJava)
-  }
-
-  private def createJeiShapedRecipe(registration: IRecipeRegistration, r: TierRecipe): RecipeHolder[CraftingRecipe] = {
-    val builder = registration.getVanillaRecipeFactory.createShapedRecipeBuilder(r.category(), new SlotDisplay.ItemStackSlotDisplay(r.result))
-    val recipe = builder
-      .group(r.group())
-      .pattern("tst")
-      .pattern("s s")
-      .pattern("tst")
-      .define('t', r.getTankItem)
-      .define('s', r.getSubItem)
-      .build()
-    val key = ResourceKey.create(Registries.RECIPE, Identifier.fromNamespaceAndPath(FluidTankCommon.modId, s"jei_dummy_${r.getTier.name.toLowerCase}"))
-    new RecipeHolder(key, recipe)
   }
 }

--- a/fabric/src/main/scala/com/kotori316/fluidtank/fabric/integration/jei/FluidTankJeiPlugin.scala
+++ b/fabric/src/main/scala/com/kotori316/fluidtank/fabric/integration/jei/FluidTankJeiPlugin.scala
@@ -6,11 +6,12 @@ import com.kotori316.fluidtank.recipe.TierRecipe
 import mezz.jei.api.constants.RecipeTypes
 import mezz.jei.api.registration.{IRecipeRegistration, IVanillaCategoryExtensionRegistration}
 import mezz.jei.api.{IModPlugin, JeiPlugin}
-import net.minecraft.client.Minecraft
+import net.fabricmc.fabric.api.client.recipe.v1.sync.ClientRecipeSynchronizedEvent
+import net.fabricmc.fabric.api.recipe.v1.sync.SynchronizedRecipes
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.{Identifier, ResourceKey}
 import net.minecraft.world.item.crafting.display.SlotDisplay
-import net.minecraft.world.item.crafting.{CraftingRecipe, RecipeHolder}
+import net.minecraft.world.item.crafting.{CraftingRecipe, RecipeHolder, RecipeType}
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.{CollectionHasAsScala, SeqHasAsJava}
@@ -18,6 +19,9 @@ import scala.jdk.CollectionConverters.{CollectionHasAsScala, SeqHasAsJava}
 @JeiPlugin
 class FluidTankJeiPlugin extends IModPlugin {
   private val LOGGER = LoggerFactory.getLogger(classOf[FluidTankJeiPlugin])
+
+  private var recipeMap: Option[SynchronizedRecipes] = None
+  ClientRecipeSynchronizedEvent.EVENT.register((client, recipes) => recipeMap = Option(recipes))
 
   override def getPluginUid: Identifier = JeiPluginConstant.pluginUid
 
@@ -29,13 +33,12 @@ class FluidTankJeiPlugin extends IModPlugin {
 
   override def registerRecipes(registration: IRecipeRegistration): Unit = {
     super.registerRecipes(registration)
-
-    // TODO how to get TierRecipes in delegated server?
-    val tierRecipes = for {
-      server <- Option(Minecraft.getInstance().getSingleplayerServer).iterator.to(IndexedSeq)
-      recipeHolder <- server.getRecipeManager.getRecipes.asScala
-      recipe <- Option(recipeHolder.value()).collect { case r: TierRecipe => r }
-    } yield createJeiShapedRecipe(registration, recipe)
+    val tierRecipes = this.recipeMap.iterator
+      .flatMap(_.getAllOfType(RecipeType.CRAFTING).asScala)
+      .map(_.value())
+      .collect { case r: TierRecipe => r }
+      .map(createJeiShapedRecipe(registration, _))
+      .toSeq
 
     LOGGER.info("Registering TierRecipe recipes for JEI with Fabric, count: {}", tierRecipes.size)
     registration.addRecipes(RecipeTypes.CRAFTING, tierRecipes.asJava)

--- a/fabric/src/test/scala/com/kotori316/fluidtank/fabric/gametest/RecipeTest.java
+++ b/fabric/src/test/scala/com/kotori316/fluidtank/fabric/gametest/RecipeTest.java
@@ -220,7 +220,10 @@ public final class RecipeTest {
             {
               "type": "%s",
               "tier": "%s",
-              "sub_item": "minecraft:apple"
+              "sub_item": "minecraft:apple",
+              "show_notification":false,
+              "category":"misc",
+              "group":"fluidtank_tank"
             }
             """.formatted(TierRecipe.Serializer.LOCATION.toString(), tier.name());
         var expectedJson = GsonHelper.parse(expected);

--- a/fabric/src/test/scala/com/kotori316/fluidtank/fabric/gametest/RecipeTest.java
+++ b/fabric/src/test/scala/com/kotori316/fluidtank/fabric/gametest/RecipeTest.java
@@ -5,11 +5,11 @@ import com.google.gson.JsonObject;
 import com.kotori316.fluidtank.FluidTankCommon;
 import com.kotori316.fluidtank.contents.GenericAmount;
 import com.kotori316.fluidtank.contents.GenericUnit;
-import com.kotori316.fluidtank.fabric.FluidTank;
 import com.kotori316.fluidtank.fabric.recipe.RecipeInventoryUtil;
 import com.kotori316.fluidtank.fluids.FluidAmountUtil;
 import com.kotori316.fluidtank.fluids.FluidLike;
 import com.kotori316.fluidtank.gametest.GameTestFunctions;
+import com.kotori316.fluidtank.gametest.recipe.RecipeTestCommon;
 import com.kotori316.fluidtank.recipe.TierRecipe;
 import com.kotori316.fluidtank.tank.Tier;
 import com.kotori316.testutil.common.TestFunction;
@@ -29,7 +29,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.*;
 import org.apache.commons.io.FilenameUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.platform.commons.function.Try;
 import org.junit.platform.commons.support.ReflectionSupport;
 import scala.jdk.javaapi.CollectionConverters;
@@ -48,7 +47,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("unused")
-public final class RecipeTest {
+public final class RecipeTest extends RecipeTestCommon {
     final Path recipeParent = Path.of("../src/generated/resources", "data/fluidtank/recipe");
 
     public RecipeTest() {
@@ -80,70 +79,8 @@ public final class RecipeTest {
             .map(m -> GameTestFunctions.create("recipe_test", TestFunction.NO_PLACE_STRUCTURE,
                 getClass().getSimpleName() + "_" + m.getName(),
                 g -> ReflectionSupport.invokeMethod(m, this, g)));
-        return Stream.concat(noArgs, withHelper).toList();
-    }
-
-    @NotNull
-    private static TierRecipe getRecipe() {
-        return new TierRecipe(
-            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
-            Tier.STONE,
-            Ingredient.of(FluidTank.TANK_MAP.get(Tier.WOOD)), Ingredient.of(Items.STONE)
-        );
-    }
-
-    void createInstance() {
-        TierRecipe recipe = getRecipe();
-        assertNotNull(recipe);
-    }
-
-    void match1() {
-        var recipe = getRecipe();
-        assertTrue(recipe.matches(RecipeInventoryUtil.getInv("tst", "s s", "tst", CollectionConverters.asScala(Map.of(
-            't', new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD)),
-            's', new ItemStack(Items.STONE)
-        ))), null));
-    }
-
-    void match2() {
-        var recipe = getRecipe();
-        var stack = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
-
-        assertTrue(recipe.matches(RecipeInventoryUtil.getInv("tst", "s s", "tst", CollectionConverters.asScala(Map.of(
-            't', stack,
-            's', new ItemStack(Items.STONE)
-        ))), null));
-    }
-
-    void match3() {
-        var recipe = getRecipe();
-        var stack = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
-
-        assertTrue(recipe.matches(RecipeInventoryUtil.getInv("tsk", "s s", "kst", CollectionConverters.asScala(Map.of(
-            't', stack,
-            'k', new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD)),
-            's', new ItemStack(Items.STONE)
-        ))), null));
-    }
-
-    void notMatch4() {
-        var recipe = getRecipe();
-        var stack = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
-        var stack2 = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, FluidAmountUtil.BUCKET_LAVA());
-
-        assertFalse(recipe.matches(RecipeInventoryUtil.getInv("tsk", "s s", "kst", CollectionConverters.asScala(Map.of(
-            't', stack,
-            'k', stack2,
-            's', new ItemStack(Items.STONE)
-        ))), null));
-    }
-
-    void notMatch5() {
-        var recipe = getRecipe();
-        assertFalse(recipe.matches(RecipeInventoryUtil.getInv("tst", "s s", "ts ", CollectionConverters.asScala(Map.of(
-            't', new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD)),
-            's', new ItemStack(Items.STONE)
-        ))), null));
+        var common = testsInCommon("recipe_test", this);
+        return Stream.of(noArgs, withHelper, common).flatMap(Function.identity()).toList();
     }
 
     public List<TestFunction> combineFluids() {
@@ -169,7 +106,7 @@ public final class RecipeTest {
 
     void combine1(GenericAmount<FluidLike> amount) {
         var filled = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, amount);
-        var empty = new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD));
+        var empty = new ItemStack(getTank(Tier.WOOD));
         var recipe = getRecipe();
 
         var inv = RecipeInventoryUtil.getInv("ksk", "s s", "kst", CollectionConverters.asScala(Map.of(
@@ -186,7 +123,7 @@ public final class RecipeTest {
 
     void combine2(GenericAmount<FluidLike> amount) {
         var filled = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, amount);
-        var empty = new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD));
+        var empty = new ItemStack(getTank(Tier.WOOD));
         var recipe = getRecipe();
 
         var inv = RecipeInventoryUtil.getInv("kst", "s s", "kst", CollectionConverters.asScala(Map.of(

--- a/fabric/src/test/scala/com/kotori316/fluidtank/fabric/gametest/RecipeTest.java
+++ b/fabric/src/test/scala/com/kotori316/fluidtank/fabric/gametest/RecipeTest.java
@@ -27,10 +27,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.world.item.crafting.Recipe;
-import net.minecraft.world.item.crafting.RecipeHolder;
-import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.item.crafting.*;
 import org.apache.commons.io.FilenameUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.platform.commons.function.Try;
@@ -88,7 +85,9 @@ public final class RecipeTest {
 
     @NotNull
     private static TierRecipe getRecipe() {
-        return new TierRecipe(Tier.STONE,
+        return new TierRecipe(
+            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
+            Tier.STONE,
             Ingredient.of(FluidTank.TANK_MAP.get(Tier.WOOD)), Ingredient.of(Items.STONE)
         );
     }
@@ -215,6 +214,7 @@ public final class RecipeTest {
     void serializeJson(GameTestHelper helper, Tier tier) {
         var subItem = Ingredient.of(Items.APPLE);
         var recipe = new TierRecipe(
+            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
             tier, TierRecipe.Serializer.getIngredientTankForTier(tier), subItem);
         String expected = """
             {
@@ -244,6 +244,7 @@ public final class RecipeTest {
     void serializePacket(GameTestHelper helper, Tier tier) {
         var subItem = Ingredient.of(Items.APPLE);
         var recipe = new TierRecipe(
+            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
             tier, TierRecipe.Serializer.getIngredientTankForTier(tier), subItem);
 
         var buffer = new RegistryFriendlyByteBuf(ByteBufAllocator.DEFAULT.buffer(), helper.getLevel().registryAccess());
@@ -267,6 +268,7 @@ public final class RecipeTest {
             """.formatted(TierRecipe.Serializer.LOCATION.toString());
         var read = assertInstanceOf(TierRecipe.class, managerFromJson(Identifier.fromNamespaceAndPath(FluidTankCommon.modId, "test_serialize"), GsonHelper.parse(jsonString), helper.getLevel().registryAccess()));
         var recipe = new TierRecipe(
+            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
             Tier.STONE, TierRecipe.Serializer.getIngredientTankForTier(Tier.STONE), Ingredient.of(Items.DIAMOND));
 
         assertAll(

--- a/gameTest/commonTest/src/main/scala/com/kotori316/fluidtank/gametest/recipe/RecipeTestCommon.java
+++ b/gameTest/commonTest/src/main/scala/com/kotori316/fluidtank/gametest/recipe/RecipeTestCommon.java
@@ -1,0 +1,172 @@
+package com.kotori316.fluidtank.gametest.recipe;
+
+import com.kotori316.fluidtank.contents.GenericAmount;
+import com.kotori316.fluidtank.fluids.FluidAmountUtil;
+import com.kotori316.fluidtank.fluids.FluidLike;
+import com.kotori316.fluidtank.fluids.PlatformFluidAccess;
+import com.kotori316.fluidtank.gametest.GameTestFunctions;
+import com.kotori316.fluidtank.recipe.TierRecipe;
+import com.kotori316.fluidtank.tank.BlockTank;
+import com.kotori316.fluidtank.tank.PlatformTankAccess;
+import com.kotori316.fluidtank.tank.Tier;
+import com.kotori316.testutil.common.TestFunction;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.*;
+import net.minecraft.world.level.GameType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public abstract class RecipeTestCommon {
+    protected static BlockTank getTank(Tier tier) {
+        return PlatformTankAccess.getInstance().getTankBlockMap().get(tier).get();
+    }
+
+    @NotNull
+    protected static TierRecipe getRecipe() {
+        return new TierRecipe(
+            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
+            Tier.STONE,
+            Ingredient.of(getTank(Tier.WOOD)), Ingredient.of(Items.STONE)
+        );
+    }
+
+    protected static CraftingInput getInv(String s1, String s2, String s3, Map<Character, ItemStack> itemMap) {
+        var map = new HashMap<>(itemMap);
+        map.put(' ', ItemStack.EMPTY);
+
+        if (s1.length() > 3 || s2.length() > 3 || s3.length() > 3) {
+            throw new IllegalArgumentException("Over 4 elements are not allowed. " + List.of(s1, s2, s3));
+        }
+        if (s1.isEmpty() && s2.isEmpty() && s3.isEmpty()) {
+            throw new IllegalArgumentException("All Empty?");
+        }
+
+        var chars = new ArrayList<Character>();
+        for (String s : List.of(s1, s2, s3)) {
+            for (int i = 0; i < s.length(); i++) {
+                chars.add(s.charAt(i));
+            }
+        }
+        if (!map.keySet().containsAll(Set.copyOf(chars))) {
+            throw new IllegalArgumentException("Contains all keys, " + chars);
+        }
+
+        var stacks = new ArrayList<ItemStack>();
+        var lines = List.of(s1, s2, s3);
+        for (String line : lines) {
+            for (int column = 0; column < line.length(); column++) {
+                var stack = map.get(line.charAt(column));
+                if (stack != null) {
+                    stacks.add(stack);
+                }
+            }
+        }
+        return CraftingInput.of(3, 3, stacks);
+    }
+
+    protected static ItemStack getFilledTankStack(GameTestHelper helper, Tier tier, GenericAmount<FluidLike> fluid) {
+        var stack = new ItemStack(getTank(tier));
+        var player = helper.makeMockPlayer(GameType.SURVIVAL); // Must be SURVIVAL because creative will not change the item itself
+        player.setItemInHand(InteractionHand.MAIN_HAND, stack);
+        var result = PlatformFluidAccess.getInstance().fillItem(fluid, stack, player, InteractionHand.MAIN_HAND, true);
+        return result.toReplace().copy();
+    }
+
+    protected static Stream<TestFunction> testsInCommon(String batchName, RecipeTestCommon self) {
+        var simpleName = RecipeTestCommon.class.getSimpleName();
+        return Stream.of(
+            GameTestFunctions.create(batchName, TestFunction.NO_PLACE_STRUCTURE, simpleName + "_" + "createInstance", self::createInstance),
+            GameTestFunctions.create(batchName, TestFunction.NO_PLACE_STRUCTURE, simpleName + "_" + "match1", self::match1),
+            GameTestFunctions.create(batchName, TestFunction.NO_PLACE_STRUCTURE, simpleName + "_" + "match2", self::match2),
+            GameTestFunctions.create(batchName, TestFunction.NO_PLACE_STRUCTURE, simpleName + "_" + "match3", self::match3),
+            GameTestFunctions.create(batchName, TestFunction.NO_PLACE_STRUCTURE, simpleName + "_" + "notMatch4", self::notMatch4),
+            GameTestFunctions.create(batchName, TestFunction.NO_PLACE_STRUCTURE, simpleName + "_" + "notMatch5", self::notMatch5),
+            GameTestFunctions.create(batchName, TestFunction.NO_PLACE_STRUCTURE, simpleName + "_" + "notMatch6", self::notMatch6),
+            GameTestFunctions.create(batchName, TestFunction.NO_PLACE_STRUCTURE, simpleName + "_" + "assumptionFillTank", self::assumptionFillTank)
+        );
+    }
+
+    void createInstance() {
+        TierRecipe recipe = getRecipe();
+        assertNotNull(recipe);
+    }
+
+    void assumptionFillTank(GameTestHelper helper) {
+        var stack = getFilledTankStack(helper, Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
+        var filled = PlatformFluidAccess.getInstance().getFluidContained(stack);
+        assertEquals(FluidAmountUtil.BUCKET_WATER(), filled);
+        helper.succeed();
+    }
+
+    void match1() {
+        var recipe = getRecipe();
+        assertTrue(recipe.matches(getInv("tst", "s s", "tst", Map.of(
+            't', new ItemStack(getTank(Tier.WOOD)),
+            's', new ItemStack(Items.STONE)
+        )), null));
+    }
+
+    void match2(GameTestHelper helper) {
+        var recipe = getRecipe();
+        var stack = getFilledTankStack(helper, Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
+
+        assertTrue(recipe.matches(getInv("tst", "s s", "tst", Map.of(
+            't', stack,
+            's', new ItemStack(Items.STONE)
+        )), null));
+        helper.succeed();
+    }
+
+    void match3(GameTestHelper helper) {
+        var recipe = getRecipe();
+        var stack = getFilledTankStack(helper, Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
+
+        assertTrue(recipe.matches(getInv("tsk", "s s", "kst", Map.of(
+            't', stack,
+            'k', new ItemStack(getTank(Tier.WOOD)),
+            's', new ItemStack(Items.STONE)
+        )), null));
+        helper.succeed();
+    }
+
+    void notMatch4(GameTestHelper helper) {
+        var recipe = getRecipe();
+        var stack = getFilledTankStack(helper, Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
+        var stack2 = getFilledTankStack(helper, Tier.WOOD, FluidAmountUtil.BUCKET_LAVA());
+
+        assertFalse(recipe.matches(getInv("tsk", "s s", "kst", Map.of(
+            't', stack,
+            'k', stack2,
+            's', new ItemStack(Items.STONE)
+        )), null));
+        helper.succeed();
+    }
+
+    void notMatch5() {
+        var recipe = getRecipe();
+        assertFalse(recipe.matches(getInv("tst", "s s", "ts ", Map.of(
+            't', new ItemStack(getTank(Tier.WOOD)),
+            's', new ItemStack(Items.STONE)
+        )), null));
+    }
+
+    void notMatch6(GameTestHelper helper) {
+        var recipe = getRecipe();
+        var stack = getFilledTankStack(helper, Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
+        var stack2 = getFilledTankStack(helper, Tier.STONE, FluidAmountUtil.BUCKET_WATER());
+
+        assertFalse(recipe.matches(getInv("tsk", "s s", "kst", Map.of(
+            't', stack,
+            'k', stack2,
+            's', new ItemStack(Items.STONE)
+        )), null));
+        helper.succeed();
+    }
+}

--- a/neoforge/src/gameTest/scala/com/kotori316/fluidtank/neoforge/gametest/RecipeTest.java
+++ b/neoforge/src/gameTest/scala/com/kotori316/fluidtank/neoforge/gametest/RecipeTest.java
@@ -21,6 +21,8 @@ import net.minecraft.resources.RegistryOps;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.neoforged.neoforge.common.conditions.WithConditions;
@@ -64,7 +66,9 @@ final class RecipeTest {
 
     @NotNull
     private static TierRecipe getRecipe() {
-        return new TierRecipe(Tier.STONE,
+        return new TierRecipe(
+            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
+            Tier.STONE,
             Ingredient.of(FluidTank.TANK_MAP.get(Tier.WOOD).get()), Ingredient.of(Items.STONE)
         );
     }
@@ -186,6 +190,7 @@ final class RecipeTest {
         var subItem = Ingredient.of(Items.APPLE);
         var id = Identifier.fromNamespaceAndPath(FluidTankCommon.modId, "test_" + tier.name().toLowerCase(Locale.ROOT));
         var recipe = new TierRecipe(
+            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
             tier, TierRecipe.Serializer.getIngredientTankForTier(tier), subItem);
         String expected = """
             {
@@ -214,7 +219,9 @@ final class RecipeTest {
 
     void serializePacket(GameTestHelper helper, Tier tier) {
         var subItem = Ingredient.of(Items.APPLE);
-        var recipe = new TierRecipe(tier, TierRecipe.Serializer.getIngredientTankForTier(tier), subItem);
+        var recipe = new TierRecipe(
+            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
+            tier, TierRecipe.Serializer.getIngredientTankForTier(tier), subItem);
 
         var buffer = new RegistryFriendlyByteBuf(ByteBufAllocator.DEFAULT.buffer(), helper.getLevel().registryAccess(), ConnectionType.OTHER);
         var streamCodec = TierRecipe.Serializer.STREAM_CODEC;
@@ -238,6 +245,7 @@ final class RecipeTest {
             """.formatted(TierRecipe.Serializer.LOCATION.toString());
         var read = assertInstanceOf(TierRecipe.class, managerFromJson(Identifier.fromNamespaceAndPath(FluidTankCommon.modId, "test_serialize"), GsonHelper.parse(jsonString), helper.getLevel().registryAccess()).orElseThrow());
         var recipe = new TierRecipe(
+            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
             Tier.STONE, TierRecipe.Serializer.getIngredientTankForTier(Tier.STONE), Ingredient.of(Items.DIAMOND));
 
         assertAll(

--- a/neoforge/src/gameTest/scala/com/kotori316/fluidtank/neoforge/gametest/RecipeTest.java
+++ b/neoforge/src/gameTest/scala/com/kotori316/fluidtank/neoforge/gametest/RecipeTest.java
@@ -7,7 +7,7 @@ import com.kotori316.fluidtank.contents.GenericUnit;
 import com.kotori316.fluidtank.fluids.FluidAmountUtil;
 import com.kotori316.fluidtank.fluids.FluidLike;
 import com.kotori316.fluidtank.gametest.GameTestFunctions;
-import com.kotori316.fluidtank.neoforge.FluidTank;
+import com.kotori316.fluidtank.gametest.recipe.RecipeTestCommon;
 import com.kotori316.fluidtank.recipe.TierRecipe;
 import com.kotori316.fluidtank.tank.Tier;
 import com.kotori316.testutil.common.TestFunction;
@@ -28,7 +28,6 @@ import net.minecraft.world.item.crafting.Recipe;
 import net.neoforged.neoforge.common.conditions.WithConditions;
 import net.neoforged.neoforge.network.connection.ConnectionType;
 import org.apache.commons.io.FilenameUtils;
-import org.jetbrains.annotations.NotNull;
 import scala.jdk.javaapi.CollectionConverters;
 
 import java.io.IOException;
@@ -43,7 +42,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("unused")
-final class RecipeTest {
+final class RecipeTest extends RecipeTestCommon {
     final Path recipeParent = Path.of("../src/generated/resources", "data/fluidtank/recipe");
 
     public RecipeTest() {
@@ -61,70 +60,11 @@ final class RecipeTest {
     }
 
     List<TestFunction> generator() {
-        return GetGameTestMethods.getTests(getClass(), this, "recipe_test");
-    }
-
-    @NotNull
-    private static TierRecipe getRecipe() {
-        return new TierRecipe(
-            new Recipe.CommonInfo(false), new CraftingRecipe.CraftingBookInfo(CraftingBookCategory.MISC, TierRecipe.TANK_RECIPE_GROUP),
-            Tier.STONE,
-            Ingredient.of(FluidTank.TANK_MAP.get(Tier.WOOD).get()), Ingredient.of(Items.STONE)
-        );
-    }
-
-    void createInstance() {
-        TierRecipe recipe = getRecipe();
-        assertNotNull(recipe);
-    }
-
-    void match1() {
-        var recipe = getRecipe();
-        assertTrue(recipe.matches(RecipeInventoryUtil.getInv("tst", "s s", "tst", CollectionConverters.<Character, ItemStack>asScala(Map.of(
-            't', new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD).get()),
-            's', new ItemStack(Items.STONE)
-        ))), null));
-    }
-
-    void match2() {
-        var recipe = getRecipe();
-        var stack = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
-
-        assertTrue(recipe.matches(RecipeInventoryUtil.getInv("tst", "s s", "tst", CollectionConverters.<Character, ItemStack>asScala(Map.of(
-            't', stack,
-            's', new ItemStack(Items.STONE)
-        ))), null));
-    }
-
-    void match3() {
-        var recipe = getRecipe();
-        var stack = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
-
-        assertTrue(recipe.matches(RecipeInventoryUtil.getInv("tsk", "s s", "kst", CollectionConverters.<Character, ItemStack>asScala(Map.of(
-            't', stack,
-            'k', new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD).get()),
-            's', new ItemStack(Items.STONE)
-        ))), null));
-    }
-
-    void notMatch4() {
-        var recipe = getRecipe();
-        var stack = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, FluidAmountUtil.BUCKET_WATER());
-        var stack2 = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, FluidAmountUtil.BUCKET_LAVA());
-
-        assertFalse(recipe.matches(RecipeInventoryUtil.getInv("tsk", "s s", "kst", CollectionConverters.<Character, ItemStack>asScala(Map.of(
-            't', stack,
-            'k', stack2,
-            's', new ItemStack(Items.STONE)
-        ))), null));
-    }
-
-    void notMatch5() {
-        var recipe = getRecipe();
-        assertFalse(recipe.matches(RecipeInventoryUtil.getInv("tst", "s s", "ts ", CollectionConverters.<Character, ItemStack>asScala(Map.of(
-            't', new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD).get()),
-            's', new ItemStack(Items.STONE)
-        ))), null));
+        var common = testsInCommon("recipe_test", this);
+        return Stream.concat(
+            GetGameTestMethods.getTests(getClass(), this, "recipe_test").stream(),
+            common
+        ).toList();
     }
 
     List<TestFunction> combineFluids() {
@@ -144,7 +84,7 @@ final class RecipeTest {
 
     void combine1(GenericAmount<FluidLike> amount) {
         var filled = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, amount);
-        var empty = new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD).get());
+        var empty = new ItemStack(getTank(Tier.WOOD));
         var recipe = getRecipe();
 
         var inv = RecipeInventoryUtil.getInv("ksk", "s s", "kst", CollectionConverters.<Character, ItemStack>asScala(Map.of(
@@ -161,7 +101,7 @@ final class RecipeTest {
 
     void combine2(GenericAmount<FluidLike> amount) {
         var filled = RecipeInventoryUtil.getFilledTankStack(Tier.WOOD, amount);
-        var empty = new ItemStack(FluidTank.TANK_MAP.get(Tier.WOOD).get());
+        var empty = new ItemStack(getTank(Tier.WOOD));
         var recipe = getRecipe();
 
         var inv = RecipeInventoryUtil.getInv("kst", "s s", "kst", CollectionConverters.<Character, ItemStack>asScala(Map.of(

--- a/neoforge/src/gameTest/scala/com/kotori316/fluidtank/neoforge/gametest/RecipeTest.java
+++ b/neoforge/src/gameTest/scala/com/kotori316/fluidtank/neoforge/gametest/RecipeTest.java
@@ -196,7 +196,10 @@ final class RecipeTest {
             {
               "type": "%s",
               "tier": "%s",
-              "sub_item": "minecraft:apple"
+              "sub_item": "minecraft:apple",
+              "show_notification":false,
+              "category":"misc",
+              "group":"fluidtank_tank"
             }
             """.formatted(TierRecipe.Serializer.LOCATION.toString(), tier.name());
         var expectedJson = GsonHelper.parse(expected);

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_bronze.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_bronze.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/bronze",
   "tier": "BRONZE"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_copper.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_copper.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/copper",
   "tier": "COPPER"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_diamond.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_diamond.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:gems/diamond",
   "tier": "DIAMOND"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_emerald.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_emerald.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:gems/emerald",
   "tier": "EMERALD"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_gold.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_gold.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/gold",
   "tier": "GOLD"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_iron.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_iron.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/iron",
   "tier": "IRON"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_lead.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_lead.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/lead",
   "tier": "LEAD"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_silver.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_silver.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/silver",
   "tier": "SILVER"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_star.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_star.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:nether_stars",
   "tier": "STAR"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_stone.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_stone.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:stones",
   "tier": "STONE"
 }

--- a/neoforge/src/generated/resources/data/fluidtank/recipe/tank_tin.json
+++ b/neoforge/src/generated/resources/data/fluidtank/recipe/tank_tin.json
@@ -9,6 +9,8 @@
     }
   ],
   "type": "fluidtank:crafting_grade_up",
+  "category": "misc",
+  "group": "fluidtank_tank",
   "sub_item": "#c:ingots/tin",
   "tier": "TIN"
 }


### PR DESCRIPTION
* Use `RecipeSynchronization.synchronizeRecipeSerializer` to sync fabric recipes to the client for JEI
* Add group and category fields to the JSON files of recipes
* Use item tags for Nether Star in Fabric
* Update changelog